### PR TITLE
Updates deepmerge dependency to use deepmerge-alt

### DIFF
--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -10,7 +10,7 @@ var slash = require('slash')
 var hmrServer = require('./hmr-server')
 var DistStyleguidePlugin = require('./webpack-plugins/DistStyleguidePlugin')
 var DocgenPlugin = require('./webpack-plugins/ReactDocgenPlugin')
-var deepmerge = require('deepmerge')
+var deepmerge = require('deepmerge-alt')
 var Promise = require('promise')
 
 /**

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "css-loader": "0.23.1",
     "cssnext": "1.8.4",
     "cssnext-loader": "1.0.1",
-    "deepmerge": "anthonator/deepmerge#feature/array-options",
+    "deepmerge-alt": "0.3.0",
     "express": "4.14.0",
     "fs-extra": "0.24.0",
     "glob": "5.0.15",


### PR DESCRIPTION
Keeping this in sync with the original rsg-alt. Apparently the deepmerge package that they were using got un-published. I still need to test to make sure the styleguide will build with this patch.

https://github.com/theogravity/react-styleguide-generator-alt/commit/a3a87b060c62577ce92360a69a0d6b00d88cb04f